### PR TITLE
Pass response body along with error

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ request('/users.json')
     console.log(error.type) //=> "EINVALIDSTATUS"
     console.log(error.message) //=> "Invalid HTTP status, 404, should be between 200 and 399"
     console.log(error.status) //=> 404
+    console.log(error.body) //=> `{"possiblyInformativeMessage":"here's why the request failed"}`
     console.log(error.popsicle) //=> Popsicle#Request
   })
 ```

--- a/popsicle-status.js
+++ b/popsicle-status.js
@@ -30,6 +30,7 @@ function popsicleStatus () {
 
       var error = req.error(req.url + ' responded with ' + res.status + ', expected it to ' + message, 'EINVALIDSTATUS')
       error.status = res.status
+      error.body = res.body
       throw error
     })
   }

--- a/test.js
+++ b/test.js
@@ -87,5 +87,13 @@ describe('popsicle status', function () {
       return popsicle.get('http://example.com')
         .use(status(200, 599))
     })
+
+    it('should pass the response body along', function () {
+      return popsicle.get('http://example.com')
+        .use(status())
+        .catch(function (err) {
+          expect(err.body).to.exist
+        })
+    })
   })
 })


### PR DESCRIPTION
Allow consumers to access any information in the body of the error response.
